### PR TITLE
Create initial CI workflow with GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,9 @@
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - run: make
+    - run: make check


### PR DESCRIPTION
Builds with make and make check on Ubuntu on pushes and pull requests. GitHub Actions can be [enabled here](https://github.com/alcover/stricks/actions).

Fun note: This is probably the fastest running CI configuration I have ever written!