### PR TITLE
Fix stx_split for self colliding separators.

### DIFF
--- a/src/stx.c
+++ b/src/stx.c
@@ -304,7 +304,12 @@ split_callback (const char* tok, const size_t len, void* ctx)
 
     if (!c->cnt) return; //should not happen - todo alert
 
-    stx_t out = stx_from(tok, len);
+    stx_t out;
+    if (len) {
+        out = stx_from(tok, len);
+    } else {
+        out = stx_from("", 0);
+    }
     *(c->out++) = out;
     --c->cnt;
 }

--- a/src/util.c
+++ b/src/util.c
@@ -24,7 +24,7 @@ str_split (const char *str, const char* sep,
         if (!strncmp(str+end, sep, seplen)) {
             callback (str + beg, end - beg, ctx);
             beg = end + seplen;
-            end = beg;
+            end = beg - 1;
         }
     }
 

--- a/src/util.c
+++ b/src/util.c
@@ -24,7 +24,7 @@ str_split (const char *str, const char* sep,
         if (!strncmp(str+end, sep, seplen)) {
             callback (str + beg, end - beg, ctx);
             beg = end + seplen;
-	    end = beg;
+            end = beg;
         }
     }
 

--- a/src/util.c
+++ b/src/util.c
@@ -24,6 +24,7 @@ str_split (const char *str, const char* sep,
         if (!strncmp(str+end, sep, seplen)) {
             callback (str + beg, end - beg, ctx);
             beg = end + seplen;
+	    end = beg;
         }
     }
 
@@ -34,7 +35,8 @@ str_split (const char *str, const char* sep,
 static inline int
 str_count_str (const char *str, const char* tok)
 {
+	const size_t toklen = strlen(tok);
 	int ret = 0;
-	for (const char* tmp = str; (tmp = strstr(tmp,tok)); ++tmp, ++ret);
+	for (const char* tmp = str; (tmp = strstr(tmp,tok)); tmp += toklen, ++ret);
 	return ret;
 }


### PR DESCRIPTION
These changes should cause 
```c
int count;
stx_t* results = stx_split("baaaad", "aa", &count);
```
to return 
```
"b"
""
"d"
```
rather than
```
"b"
"aad"
"ad"
"d"
```