### PR TITLE
CI: Add jobs for Clang, c99 and c17 and -O3 to build matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,9 +8,17 @@ jobs:
       matrix:
         CC: [gcc, clang]
         STD: [c99, c11, c17]
+        OPTIM: [-O0]
+        include:
+          - CC: gcc
+            STD: c17
+            OPTIM: -O3
+          - CC: clang
+            STD: c17
+            OPTIM: -O3
 
     env:
-      make_options: 'CC=${{ matrix.CC }} STD=${{ matrix.STD }}' 
+      make_options: 'CC=${{ matrix.CC }} STD=${{ matrix.STD }} OPTIM=${{ matrix.OPTIM }}' 
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,16 @@ on: [push, pull_request]
 jobs:
   build:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        CC: [gcc, clang]
+
+    env:
+      make_options: 'CC=${{ matrix.CC }}' 
+
     steps:
     - uses: actions/checkout@v2
-    - run: make
-    - run: make check
+    - run: make -n $make_options
+    - run: make $make_options
+    - run: make check $make_options

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,9 +7,10 @@ jobs:
       fail-fast: false
       matrix:
         CC: [gcc, clang]
+        STD: [c99, c11, c17]
 
     env:
-      make_options: 'CC=${{ matrix.CC }}' 
+      make_options: 'CC=${{ matrix.CC }} STD=${{ matrix.STD }}' 
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,18 +7,10 @@ jobs:
       fail-fast: false
       matrix:
         CC: [gcc, clang]
-        STD: [c99, c11, c17]
-        OPTIM: [-O0]
-        include:
-          - CC: gcc
-            STD: c17
-            OPTIM: -O3
-          - CC: clang
-            STD: c17
-            OPTIM: -O3
+        OPTIM: [-O0, -O2]
 
     env:
-      make_options: 'CC=${{ matrix.CC }} STD=${{ matrix.STD }} OPTIM=${{ matrix.OPTIM }}' 
+      make_options: 'CC=${{ matrix.CC }} OPTIM=${{ matrix.OPTIM }}'
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Expands the GitHub Actions CI build matrix to eight jobs:
 - All combinations of two compilers (GCC and Clang) and C standards (c99, c11 and c17)
 - Two optimized `-O3` builds using GCC and Clang for c17.

I split this PR into 3 commits, each adding one option:

1. Different compilers (GCC and Clang)
2. Different C standards (c99, c11 and c17)
3. The `-O3` optimization level for c17

If you have any questions, find some combinations not useful or would like to have some combinations added, please let me know!